### PR TITLE
Set top-level permissions of CD workflow to none

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,6 +9,8 @@ on:
     types: [completed]
     branches: [mainline]
 
+permissions: {}
+
 jobs:
   verify:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## What are these changes?
Set top-level permissions in the CD workflow to none.

## Why are these changes being made?
To address [Code scanning #22](https://github.com/AJGranowski/reddit-expanded-community-filter-userscript/security/code-scanning/22).