### PR TITLE
Harden CI runners

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -25,7 +25,8 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
@@ -35,7 +36,8 @@ jobs:
     - name: "Print Parent"
       run: echo "${{ github.event.workflow_run.html_url }}"
 
-    - uses: dawidd6/action-download-artifact@72aaadce3bc708349fc665eee3785cbb1b6e51d0 # v3.1.1
+    - name: Download CI Artifacts
+      uses: dawidd6/action-download-artifact@72aaadce3bc708349fc665eee3785cbb1b6e51d0 # v3.1.1
       with:
         run_id: ${{ github.event.workflow_run.id }}
         name: artifacts
@@ -59,7 +61,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Rootless Docker
         uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
@@ -70,7 +73,8 @@ jobs:
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('./Dockerfile', './images/yq/Dockerfile') }}
 
-      - uses: dawidd6/action-download-artifact@72aaadce3bc708349fc665eee3785cbb1b6e51d0 # v3.1.1
+      - name: Download CI Artifacts
+        uses: dawidd6/action-download-artifact@72aaadce3bc708349fc665eee3785cbb1b6e51d0 # v3.1.1
         with:
           run_id: ${{ github.event.workflow_run.id }}
           name: artifacts
@@ -113,7 +117,8 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+      - name: Download Signed Artifacts
+        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
         with:
           name: signed-artifacts
           path: artifacts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,11 @@ jobs:
       actions: write
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Node.js
@@ -49,6 +54,11 @@ jobs:
     runs-on: ubuntu-latest
     environment: signature
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Use Rootless Docker
@@ -98,6 +108,11 @@ jobs:
       cancel-in-progress: true
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
       - uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
         with:
           name: signed-artifacts

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         node-version: lts/*
 
-    - name: "Print Parent"
+    - name: Print Parent
       run: echo "${{ github.event.workflow_run.html_url }}"
 
     - name: Download CI Artifacts
@@ -43,10 +43,10 @@ jobs:
         name: artifacts
         path: artifacts
 
-    - name: "Verify the deploymenet artifacts"
+    - name: Verify the deploymenet artifacts
       run: echo "VERIFY_STATUS=$(node scripts/verifyDeploy.js artifacts/script.user.js artifacts/script.meta.js >/dev/null 2>&1 && echo success || echo failure)" >> $GITHUB_ENV
     
-    - name: "Cancel workflow on verify failure"
+    - name: Cancel workflow on verify failure
       if: ${{ env.VERIFY_STATUS == 'failure' }}
       uses: andymckay/cancel-action@271cfbfa11ca9222f7be99a47e8f929574549e0a # 0.4
 
@@ -67,7 +67,7 @@ jobs:
       - name: Use Rootless Docker
         uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
 
-      - name: "Docker Cache"
+      - name: Docker Cache
         id: docker-cache
         uses: ScribeMD/docker-cache@e481e638abdb45e2fa30845305c387a544cc617f # 0.3.7
         with:
@@ -80,7 +80,7 @@ jobs:
           name: artifacts
           path: build/release/
 
-      - name: "Sign Artifacts"
+      - name: Sign Artifacts
         run: |
           mkdir -p ~/.minisign
           echo '${{ secrets.MINISIGN_PRIVATE_BASE64 }}' | base64 -d > ~/.minisign/minisign.key
@@ -88,12 +88,12 @@ jobs:
           MINISIGN_KEY_PATH='~/.minisign/minisign.key' ./toolbox -- run sign
           rm ~/.minisign/minisign.key
 
-      - name: "Verify Signatures"
+      - name: Verify Signatures
         run: |
           chmod +x "./toolbox"
           ./toolbox -- run sign:verify
 
-      - name: "Upload Signed Artifacts"
+      - name: Upload Signed Artifacts
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: signed-artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,37 +41,37 @@ jobs:
       with:
         egress-policy: audit
 
-    - name: "Checkout"
+    - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Rootless Docker
       if: ${{ matrix.docker-context == 'rootless' }}
       uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
 
-    - name: "Validate Docker Compose Files"
+    - name: Validate Docker Compose Files
       run: |
         docker compose --file docker-compose.yml config --quiet
         docker compose --file docker-compose.watch-build-server.yml config --quiet
 
-    - name: "Docker Cache"
+    - name: Docker Cache
       id: docker-cache
       uses: ScribeMD/docker-cache@e481e638abdb45e2fa30845305c387a544cc617f # 0.3.7
       with:
         key: docker-${{ runner.os }}-${{ hashFiles('./Dockerfile', './images/yq/Dockerfile') }}
     
-    - name: "NPM Cache"
+    - name: NPM Cache
       id: npm-cache
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       with:
         path: "~/.npm/_cacache"
         key: npm-${{ runner.os }}-${{ hashFiles('./package-lock.json') }}
 
-    - name: "Build and Verify"
+    - name: Build and Verify
       run: |
         chmod +x "./toolbox"
         ./toolbox -- run clean-verify
 
-    - name: "Upload Artifacts"
+    - name: Upload Artifacts
       if: ${{ matrix.docker-context == 'rootless' }}
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
         docker-context: ["rootless", "default"]
 
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        egress-policy: audit
+
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Rootless Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,10 @@ jobs:
         docker-context: ["rootless", "default"]
 
     steps:
-    - name: Use Rootless Docker
-      if: ${{ matrix.docker-context == 'rootless' }}
-      uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
-  
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
-        disable-sudo: true
+        disable-sudo: ${{ matrix.docker-context != 'rootless' }}
         egress-policy: block
         allowed-endpoints: >
           auth.docker.io:443
@@ -52,6 +48,10 @@ jobs:
           production.cloudflare.docker.com:443
           registry-1.docker.io:443
           registry.npmjs.org:443
+    
+    - name: Use Rootless Docker
+      if: ${{ matrix.docker-context == 'rootless' }}
+      uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
 
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,17 +36,25 @@ jobs:
         docker-context: ["rootless", "default"]
 
     steps:
-    - name: Harden Runner
-      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-      with:
-        egress-policy: audit
-
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
     - name: Use Rootless Docker
       if: ${{ matrix.docker-context == 'rootless' }}
       uses: ScribeMD/rootless-docker@6bd157a512c2fafa4e0243a8aa87d964eb890886 # 0.2.2
+  
+    - name: Harden Runner
+      uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+      with:
+        disable-sudo: true
+        egress-policy: block
+        allowed-endpoints: >
+          auth.docker.io:443
+          dl-cdn.alpinelinux.org:443
+          github.com:443
+          production.cloudflare.docker.com:443
+          registry-1.docker.io:443
+          registry.npmjs.org:443
+
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Validate Docker Compose Files
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
+        disable-sudo: ${{ matrix.docker-context != 'rootless' }}
         egress-policy: block
         allowed-endpoints: >
           auth.docker.io:443

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,12 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
       with:
-        disable-sudo: ${{ matrix.docker-context != 'rootless' }}
         egress-policy: block
         allowed-endpoints: >
           auth.docker.io:443
           dl-cdn.alpinelinux.org:443
+          download.docker.com:443
+          get.docker.com:443
           github.com:443
           production.cloudflare.docker.com:443
           registry-1.docker.io:443

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,8 @@ jobs:
       with:
         egress-policy: audit
 
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: "Checkout"
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
     - name: Use Rootless Docker
       if: ${{ matrix.docker-context == 'rootless' }}


### PR DESCRIPTION
## What are these changes?
Add [step-security/harden-runner](https://github.com/step-security/harden-runner) to CI/CD workflows.

## Why are these changes being made?
Lowers the risk of updating third party actions in the CI/CD workflow.