### PR TITLE
Add internationalization support

### DIFF
--- a/locale/en.internal.json
+++ b/locale/en.internal.json
@@ -1,0 +1,19 @@
+{
+    "locale": "en",
+    "translation": {
+        "debugMenu": {
+            "enableDebugMode": {
+                "_description": "Pressing this button will enable debug mode.",
+                "text": "Enable Debug Mode"
+            },
+            "disableDebugMode": {
+                "_description": "Pressing this button will disable debug mode.",
+                "text": "Disable Debug Mode"
+            }
+        },
+        "totalMutedPosts": {
+            "_description": "The total number of posts muted by this script. {#} will be replaced a number at runtime.",
+            "text": "Total Muted Posts: {#}"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     },
     "type": "module",
     "scripts": {
+        "build": "npm run build:typescript && npm run build:rollup && npm run build:release",
         "build:release": "node scripts/buildRelease.js ${npm_package_config_rollupDir}/bundle.js ${npm_package_config_releaseDir}",
         "build:rollup": "npm exec --no -- rollup -c rollup.config.js",
         "build:typescript": "npm exec --no -- tsc --outDir ${npm_package_config_typescriptDir}",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reddit-expanded-community-filter-userscript",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "Filter muted communities from /r/all",
     "keywords": [
         "reddit",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "config": {
         "buildDir": "build/",
         "jestCoverageDir": "build/jest-coverage/",
+        "localeDir": "locale/",
         "releaseDir": "build/release/",
         "releaseScriptMeta": "script.meta.js",
         "releaseScriptUser": "script.user.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,7 +23,7 @@ export default [
             internalJSON(),
             json({
                 compact: true,
-                include: path.join(pkg.config.typescriptDir, "locale", "*"),
+                include: path.join(pkg.config.typescriptDir, pkg.config.localeDir, "*"),
                 namedExports: false,
                 preferConst: true
             }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,7 +11,7 @@ import pkg from "./package.json" assert { type: "json" };
 
 export default [
     {
-        input: path.join(pkg.config.typescriptDir, "index.js"),
+        input: path.join(pkg.config.typescriptDir, pkg.config.srcDir, "index.js"),
         output: [
             {
                 file: path.join(pkg.config.rollupDir, "bundle.js"),
@@ -23,6 +23,7 @@ export default [
             internalJSON(),
             json({
                 compact: true,
+                include: path.join(pkg.config.typescriptDir, "locale", "*"),
                 namedExports: false,
                 preferConst: true
             }),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import commonjs from "@rollup/plugin-commonjs";
+import internalJSON from "./scripts/rollup-plugin-internal-json.js";
 import json from "@rollup/plugin-json";
 import metablock from "rollup-plugin-userscript-metablock";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -19,7 +20,12 @@ export default [
             }
         ],
         plugins: [
-            json(),
+            internalJSON(),
+            json({
+                compact: true,
+                namedExports: false,
+                preferConst: true
+            }),
             nodeResolve({
                 browser: true,
                 preferBuiltins: false
@@ -56,6 +62,7 @@ export default [
                  *
                  * Some final formatting after terser.
                  */
+                bracketSpacing: false,
                 parser: "babel",
                 printWidth: 120,
                 trailingComma: "none"

--- a/scripts/rollup-plugin-internal-json.js
+++ b/scripts/rollup-plugin-internal-json.js
@@ -1,0 +1,70 @@
+function isEmpty(object) {
+    for (const key in object) {
+        if (Object.hasOwn(object, key)) {
+            return false;
+        }
+    }
+
+    return typeof object === "object";
+}
+
+function removeUnderscoreReviver(key, value) {
+    return key.startsWith("_") ? undefined : value;
+}
+
+function removeEmptyObjectReviver(key, value) {
+    if (typeof value !== "object") {
+        return value;
+    }
+
+    if (Array.isArray(value)) {
+        return value.filter((x) => !isEmpty(x));
+    } else if (isEmpty(value)) {
+        return undefined;
+    }
+
+    return value;
+}
+
+/**
+ * Combine a series of revivers into one reviver.
+ * Revivers run in order, and short circuit on undefined.
+ */
+function compoundReviver(...revivers) {
+    return (key, value) => {
+        let result = value;
+        for (const reviver of revivers) {
+            if (result === undefined) {
+                return result;
+            }
+
+            result = reviver(key, result);
+        }
+
+        return result;
+    };
+}
+
+/**
+ * Transform internal JSON to production JSON.
+ * * Removes private properties (those that start with an underscore).
+ * * Removes empty objects while retaining empty arrays.
+ */
+export default function() {
+    return {
+        name: "rollup-plugin-internal-json",
+        transform: (source, id) => {
+            if (!id.toLowerCase().endsWith(".internal.json")) {
+                return null;
+            }
+
+            const reviver = compoundReviver(removeUnderscoreReviver, removeEmptyObjectReviver);
+            try {
+                return JSON.stringify(JSON.parse(source, reviver));
+            } catch (e) {
+                console.warn(id, e);
+                return null;
+            }
+        }
+    };
+}

--- a/scripts/rollup-plugin-internal-json.js
+++ b/scripts/rollup-plugin-internal-json.js
@@ -13,7 +13,7 @@ function removeUnderscoreReviver(key, value) {
 }
 
 function removeEmptyObjectReviver(key, value) {
-    if (typeof value !== "object") {
+    if (value == null || typeof value !== "object") {
         return value;
     }
 

--- a/src/i18n/@types/DeepReadonly.ts
+++ b/src/i18n/@types/DeepReadonly.ts
@@ -1,0 +1,5 @@
+type DeepReadonly<T> = {
+    readonly [K in keyof T]: DeepReadonly<T[K]>
+}
+
+export { DeepReadonly };

--- a/src/i18n/@types/InternalJSON.ts
+++ b/src/i18n/@types/InternalJSON.ts
@@ -1,0 +1,22 @@
+type RemoveUnderscore<T extends object> = {
+    [K in keyof T as Exclude<K, `_${string}`>]:
+        T[K] extends object ? RemoveUnderscore<T[K]> : T[K]
+}
+
+type RemoveEmptyObjects<T extends object> = {
+    [K in keyof T as T[K] extends Record<string, never> ? never : K]:
+        T[K] extends object ? RemoveEmptyObjects<T[K]> : T[K]
+}
+
+// Removing empty objects could result in more empty objects, that if removed could result in more empty objects...
+type RecursivelyRemoveEmptyObjects<T extends object> = RemoveEmptyObjects<T> extends T ?
+    T : RecursivelyRemoveEmptyObjects<RemoveEmptyObjects<T>>;
+
+/**
+ * Transform internal JSON type to production JSON type.
+ * * Removes private properties (those that start with an underscore).
+ * * Removes empty objects while retaining empty arrays.
+ */
+type InternalJSON<T extends object> = RecursivelyRemoveEmptyObjects<RemoveUnderscore<T>>;
+
+export { InternalJSON };

--- a/src/i18n/@types/Translation.ts
+++ b/src/i18n/@types/Translation.ts
@@ -1,0 +1,6 @@
+interface Translation<Locale extends string> {
+    locale: Locale,
+    translation: any
+}
+
+export { Translation };

--- a/src/i18n/Localization.ts
+++ b/src/i18n/Localization.ts
@@ -3,12 +3,29 @@ import { InternalJSON } from "./@types/InternalJSON";
 import { mergeDeep } from "../utilities/MergeDeep";
 import { Translation } from "./@types/Translation";
 
+import en from "../../locale/en.internal.json";
+
 class Localization<TF extends Translation<string>, L extends TF["locale"]> {
+    static get SINGLETON(): ReturnType<typeof this.loadSingleton> {
+        if (this.singleton == null) {
+            this.singleton = this.loadSingleton();
+        }
+
+        return this.singleton;
+    }
+
+    // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+    private static loadSingleton() {
+        return new Localization(en);
+    }
+
+    private static singleton: ReturnType<typeof this.loadSingleton> | null = null;
+
     readonly fallbackTranslation: InternalJSON<TF>;
 
     currentLocale: L | null;
     currentTranslation: InternalJSON<TF> | null;
-    preferredLocales: string[];
+    preferredLocales: readonly string[];
     translations: Record<L, InternalJSON<TF>>;
 
     constructor(defaultTranslation: TF) {
@@ -30,7 +47,7 @@ class Localization<TF extends Translation<string>, L extends TF["locale"]> {
         return this.currentTranslation == null ? this.fallbackTranslation : this.currentTranslation;
     }
 
-    setPreferredLanguages(preferredLanguages: string[]): void {
+    setPreferredLanguages(preferredLanguages: readonly string[]): void {
         this.preferredLocales = preferredLanguages;
         this.populateCurrentTranslation();
     }

--- a/src/i18n/Localization.ts
+++ b/src/i18n/Localization.ts
@@ -1,0 +1,58 @@
+import { DeepReadonly } from "./@types/DeepReadonly";
+import { InternalJSON } from "./@types/InternalJSON";
+
+interface Translation {
+    locale: string,
+    translation: any
+}
+
+class Localization <FT extends Translation, T extends InternalJSON<FT["translation"]>> {
+    readonly fallbackTranslation: T;
+
+    preferredLanguages: string[];
+    translations: Record<string, T>;
+
+    constructor(defaultTranslation: FT) {
+        this.fallbackTranslation = defaultTranslation.translation;
+        this.preferredLanguages = [];
+        this.translations = {[defaultTranslation.locale]: defaultTranslation.translation};
+    }
+
+    addTranslation(translation: Translation): void {
+        this.translations[translation.locale] = translation.translation;
+    }
+
+    get(): DeepReadonly<T> {
+        // return this.translations[this.currentLanguage] or this.fallbackTranslation?
+        return this.fallbackTranslation;
+    }
+
+    setLanguage(preferredLanguages: string[]): void {
+        this.preferredLanguages = preferredLanguages;
+    }
+
+    private getClosestMatchingTranslation(/*translations: Record<string, T>, preferredLanguages: string[]*/): any {
+        // Merge translation with fallback?
+        // NO, WAIT. PROXIES. PROXIES MY GUY. HOLYSHIT. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy
+        // Nah... I might need to add a proxy for each property. Might as well just merge with the fallback when adding the translation.
+        return null;
+    }
+}
+
+const translationFile = {
+    locale: "en-US",
+    translation: {
+        hello: "world",
+        nice: "to meet you!",
+        dive: {
+            deep: "down"
+        },
+        _remove: "this",
+        and: {}
+    }
+};
+
+const localization = new Localization(translationFile);
+console.log(localization.get());
+
+export { Localization };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { DebugMenu } from "./userscript/DebugMenu";
+import { Localization } from "./i18n/Localization";
 import { RedditExpandedCommunityFilter } from "./RedditExpandedCommunityFilter";
 import { Storage, STORAGE_KEY } from "./userscript/Storage";
 import { TotalMutedPostsCounter } from "./userscript/TotalMutedPostsCounter";
+
+window.addEventListener("languagechange", () => {
+    Localization.SINGLETON.setPreferredLanguages(navigator.languages);
+});
 
 const redditExpandedCommunityFilter = new RedditExpandedCommunityFilter();
 const debugMenu = new DebugMenu((enableDebug) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { RedditExpandedCommunityFilter } from "./RedditExpandedCommunityFilter";
 import { Storage, STORAGE_KEY } from "./userscript/Storage";
 import { TotalMutedPostsCounter } from "./userscript/TotalMutedPostsCounter";
 
+Localization.SINGLETON.setPreferredLanguages(navigator.languages);
 window.addEventListener("languagechange", () => {
     Localization.SINGLETON.setPreferredLanguages(navigator.languages);
 });

--- a/src/userscript/DebugMenu.ts
+++ b/src/userscript/DebugMenu.ts
@@ -1,4 +1,7 @@
+import { Localization } from "../i18n/Localization";
 import { Storage, STORAGE_KEY } from "./Storage";
+
+const i18n = Localization.SINGLETON;
 
 class DebugMenu {
     private readonly callback?: (enableDebug: boolean) => void;
@@ -49,7 +52,7 @@ class DebugMenu {
         }
 
         if (this.enableDebugId == null) {
-            this.enableDebugId = GM_registerMenuCommand("Disable Debug Mode", () => {
+            this.enableDebugId = GM_registerMenuCommand(i18n.get().debugMenu.disableDebugMode.text, () => {
                 this.storage.set(STORAGE_KEY.DEBUG, false);
             });
         }
@@ -62,7 +65,7 @@ class DebugMenu {
         }
 
         if (this.disableDebugId == null) {
-            this.disableDebugId = GM_registerMenuCommand("Enable Debug Mode", () => {
+            this.disableDebugId = GM_registerMenuCommand(i18n.get().debugMenu.enableDebugMode.text, () => {
                 this.storage.set(STORAGE_KEY.DEBUG, true);
             });
         }

--- a/src/userscript/TotalMutedPostsCounter.ts
+++ b/src/userscript/TotalMutedPostsCounter.ts
@@ -1,4 +1,7 @@
+import { Localization } from "../i18n/Localization";
 import { Storage, STORAGE_KEY } from "./Storage";
+
+const i18n = Localization.SINGLETON;
 
 class TotalMutedPostsCounter {
     private readonly storage: Storage;
@@ -43,7 +46,8 @@ class TotalMutedPostsCounter {
             this.counterId = null;
         }
 
-        this.counterId = GM_registerMenuCommand(`Total Muted Posts: ${count}`, this.emptyFunction);
+        const name = i18n.get().totalMutedPosts.text.replaceAll("{#}", count.toString());
+        this.counterId = GM_registerMenuCommand(name, this.emptyFunction);
     }
 
     private readonly valueChangeListener = (name: string, oldValue: number, newValue: number): void => {

--- a/src/utilities/MergeDeep.ts
+++ b/src/utilities/MergeDeep.ts
@@ -1,0 +1,26 @@
+// Sourced from https://stackoverflow.com/a/34749873
+
+function isObject(item: any): boolean {
+    return (item != null && typeof item === "object" && !Array.isArray(item));
+}
+
+/**
+ * Merge a source object into a target object
+ */
+function mergeDeep <T1 extends Record<string, any>, T2 extends Record<string, any>>(target: T1, source: T2): T1 | T2 {
+    for (const key in source) {
+        if (isObject(source[key])) {
+            if (!(key in target)) {
+                Object.assign(target, {[key]: {}});
+            }
+
+            mergeDeep(target[key], source[key]);
+        } else {
+            Object.assign(target, {[key]: source[key]});
+        }
+    }
+
+    return target;
+}
+
+export { mergeDeep };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
         "noImplicitAny": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
+        "resolveJsonModule": true,
         "sourceMap": true,
         "strictBindCallApply": true,
         "strictFunctionTypes": true,

--- a/tst/i18n/Localization.test.ts
+++ b/tst/i18n/Localization.test.ts
@@ -1,0 +1,134 @@
+import { Localization } from "../../src/i18n/Localization";
+import { Translation } from "../../src/i18n/@types/Translation";
+
+describe("Localization", () => {
+    describe("get", () => {
+        it("should return the default language without any other languages", () => {
+            const defaultLanguage = {
+                locale: "default-lang",
+                translation: {
+                    text: "Hello world!"
+                }
+            } satisfies Translation<"default-lang">;
+
+            const localization = new Localization(defaultLanguage);
+            const get = localization.get() satisfies typeof defaultLanguage["translation"];
+            expect(get).toEqual(defaultLanguage.translation);
+        });
+
+        it("should return the default language if preferred language does not exist", () => {
+            const defaultLanguage = {
+                locale: "default-lang",
+                translation: {
+                    text: "Hello world!"
+                }
+            } satisfies Translation<"default-lang">;
+
+            const localization = new Localization(defaultLanguage);
+            localization.setPreferredLanguages(["something-different"]);
+            expect(localization.get()).toEqual(defaultLanguage.translation);
+        });
+    });
+
+    describe("addTranslation", () => {
+        it("should switch between two languages", () => {
+            const languageA = {
+                locale: "lang-A",
+                translation: {
+                    text: "Hello!"
+                }
+            } satisfies Translation<"lang-A">;
+
+            const languageB = {
+                locale: "lang-B",
+                translation: {
+                    text: "What's up!"
+                }
+            } satisfies Translation<"lang-B">;
+
+            const localization = new Localization(languageA)
+                .addTranslation(languageB);
+
+            localization.setPreferredLanguages(["lang-A"]);
+            expect(localization.get().text).toEqual(languageA.translation.text);
+
+            localization.setPreferredLanguages(["lang-B"]);
+            expect(localization.get().text).toEqual(languageB.translation.text);
+        });
+
+        it("should fallback to default language if translation not found", () => {
+            const languageA = {
+                locale: "lang-A",
+                translation: {
+                    foo: "foo",
+                    bar: "bar"
+                }
+            } satisfies Translation<"lang-A">;
+
+            const languageB = {
+                locale: "lang-B",
+                translation: {
+                    bar: "baz"
+                }
+            } satisfies Translation<"lang-B">;
+
+            const localization = new Localization(languageA)
+                .addTranslation(languageB);
+
+            localization.setPreferredLanguages(["lang-B"]);
+            expect(localization.get().foo).toEqual(languageA.translation.foo);
+            expect(localization.get().bar).toEqual(languageB.translation.bar);
+        });
+    });
+
+    describe("setPreferredLanguages", () => {
+        it("should no-op if changing the language to the current language", () => {
+            const defaultLanguage = {
+                locale: "default-lang",
+                translation: {
+                    text: "Hello world!"
+                }
+            } satisfies Translation<"default-lang">;
+
+            const localization = new Localization(defaultLanguage);
+            localization.setPreferredLanguages([defaultLanguage.locale]);
+            expect(localization.get()).toEqual(defaultLanguage.translation);
+        });
+
+        it("should return the first matching locale from the list of preferred languages", () => {
+            const languageA = {
+                locale: "lang-A",
+                translation: {
+                    text: "A"
+                }
+            } satisfies Translation<"lang-A">;
+
+            const languageAA = {
+                locale: "lang-A-AA",
+                translation: {
+                    text: "AA"
+                }
+            } satisfies Translation<"lang-A-AA">;
+
+            const languageB = {
+                locale: "lang-B",
+                translation: {
+                    text: "B"
+                }
+            } satisfies Translation<"lang-B">;
+
+            const localization = new Localization(languageA)
+                .addTranslation(languageAA)
+                .addTranslation(languageB);
+
+            localization.setPreferredLanguages(["lang-A-AA", "lang-A"]);
+            expect(localization.get().text).toEqual(languageAA.translation.text);
+
+            localization.setPreferredLanguages(["lang-A", "lang-A-AA"]);
+            expect(localization.get().text).toEqual(languageA.translation.text);
+
+            localization.setPreferredLanguages(["does-not-exit", "something-else", "lang-B"]);
+            expect(localization.get().text).toEqual(languageB.translation.text);
+        });
+    });
+});

--- a/tst/utilities/MergeDeep.test.ts
+++ b/tst/utilities/MergeDeep.test.ts
@@ -1,0 +1,81 @@
+import { mergeDeep } from "../../src/utilities/MergeDeep";
+
+describe("mergeDeep", () => {
+    it("should merge empty objects", () => {
+        expect(mergeDeep({}, {})).toEqual({});
+    });
+
+    it("should merge first level properties", () => {
+        expect(mergeDeep({a: 1}, {b: 2})).toEqual({a: 1, b: 2});
+    });
+
+    it("should merge second level properties", () => {
+        const target = {
+            a: {
+                foo: "foo"
+            }
+        };
+
+        const source = {
+            b: {
+                bar: "foo"
+            }
+        };
+
+        const expected = {
+            a: {
+                foo: "foo"
+            },
+            b: {
+                bar: "foo"
+            }
+        };
+
+        expect(mergeDeep(target, source)).toEqual(expected);
+    });
+
+    it("should modify target object", () => {
+        const target = {};
+        mergeDeep(target, {foo: "bar"});
+        expect(target).toEqual({foo: "bar"});
+    });
+
+    it("should not modify source object", () => {
+        const source = {};
+        mergeDeep({bar: "foo"}, source);
+        expect(source).toEqual({});
+    });
+
+    it("should overwrite target properties that also appear in the source", () => {
+        expect(mergeDeep({a: 1}, {a: 2})).toEqual({a: 2});
+    });
+
+    it("should merge third level properties", () => {
+        const target = {
+            a: {
+                b: {
+                    foo: "foo"
+                }
+            }
+        };
+
+        const source = {
+            a: {
+                b: {
+                    bar: "bar"
+                }
+            }
+        };
+
+        const expected = {
+            a: {
+                b: {
+                    foo: "foo",
+                    bar: "bar"
+                }
+            }
+        };
+
+        expect(mergeDeep(source, target)).toEqual(expected);
+    });
+});


### PR DESCRIPTION
## What are these changes?
Add localization support.

* Created `rollup-plugin-internal-json` to strip development fields from JSON for production code.
* Added `Localization` to manage adding and changing translations.
* Added simple `en` translations for the three strings in this project.

## Why are these changes being made?
This change resolves #155 by adding a system to change strings depending on the users language.

## Checklist before merging
- [X] `./toolbox -- run clean-verify` succeeds.