### PR TITLE
Fix linter warnings/errors in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         ./toolbox -- run clean-verify
     
     - name: Upload Code Coverage
-      if: ${{ steps.changed-files.outputs.paths_any_changed == 'true' }}
+      if: ${{ matrix.docker-context == 'rootless' && steps.changed-files.outputs.paths_any_changed == 'true' }}
       uses: coverallsapp/github-action@3dfc5567390f6fa9267c0ee9c251e4c8c3f18949 # v2.2.3
 
     - name: Upload Artifacts

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -98,9 +98,7 @@ export default tseslint.config(
         ...jestPlugin.configs["flat/recommended"],
         files: [`${pkg.config.tstDir}/**`],
         rules: {
-            ...jestPlugin.configs["flat/recommended"].rules,
-            "jest/no-alias-methods": "warn",
-            "jest/no-conditional-expect": "warn"
+            ...jestPlugin.configs["flat/recommended"].rules
         }
     }
 );

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -96,9 +96,6 @@ export default tseslint.config(
     },
     {
         ...jestPlugin.configs["flat/recommended"],
-        files: [`${pkg.config.tstDir}/**`],
-        rules: {
-            ...jestPlugin.configs["flat/recommended"].rules
-        }
+        files: [`${pkg.config.tstDir}/**`]
     }
 );

--- a/tst/RedditExpandedCommunityFilter.test.ts
+++ b/tst/RedditExpandedCommunityFilter.test.ts
@@ -67,7 +67,7 @@ describe("RedditExpandedCommunityFilter", () => {
     });
 
     test("stop should resolve immediately if not started", async () => {
-        await redditExpandedCommunityFilter.stop();
+        return expect(redditExpandedCommunityFilter.stop()).resolves.not.toThrow();
     });
 
     test("start should return the same promise", () => {
@@ -140,7 +140,7 @@ describe("RedditExpandedCommunityFilter", () => {
 
         test("promise should resolve on stop", async () => {
             redditExpandedCommunityFilter.stop();
-            await startPromise;
+            return expect(startPromise).resolves.not.toThrow();
         });
 
         describe("post removal", () => {
@@ -175,6 +175,6 @@ describe("RedditExpandedCommunityFilter", () => {
     test("promise should resolve on stop", async () => {
         const promise = redditExpandedCommunityFilter.start();
         redditExpandedCommunityFilter.stop();
-        await promise;
+        return expect(promise).resolves.not.toThrow();
     });
 });

--- a/tst/RedditExpandedCommunityFilter.test.ts
+++ b/tst/RedditExpandedCommunityFilter.test.ts
@@ -67,7 +67,7 @@ describe("RedditExpandedCommunityFilter", () => {
     });
 
     test("stop should resolve immediately if not started", async () => {
-        return expect(redditExpandedCommunityFilter.stop()).resolves.not.toThrow();
+        await expect(redditExpandedCommunityFilter.stop()).resolves.not.toThrow();
     });
 
     test("start should return the same promise", () => {
@@ -140,7 +140,7 @@ describe("RedditExpandedCommunityFilter", () => {
 
         test("promise should resolve on stop", async () => {
             redditExpandedCommunityFilter.stop();
-            return expect(startPromise).resolves.not.toThrow();
+            await expect(startPromise).resolves.not.toThrow();
         });
 
         describe("post removal", () => {
@@ -175,6 +175,6 @@ describe("RedditExpandedCommunityFilter", () => {
     test("promise should resolve on stop", async () => {
         const promise = redditExpandedCommunityFilter.start();
         redditExpandedCommunityFilter.stop();
-        return expect(promise).resolves.not.toThrow();
+        await expect(promise).resolves.not.toThrow();
     });
 });

--- a/tst/reddit/AccessToken.test.ts
+++ b/tst/reddit/AccessToken.test.ts
@@ -82,7 +82,7 @@ describe("AccessToken", () => {
         });
 
         test("should throw error if ___r doesn't exist on the Window object", () => {
-            expect(() => accessTokenInstance.fromWindow({} as any)).toThrowError();
+            expect(() => accessTokenInstance.fromWindow({} as any)).toThrow();
         });
     });
 
@@ -96,17 +96,15 @@ describe("AccessToken", () => {
         });
 
         test("should throw error if data ID doesn't exist on the Document object", () => {
-            /* eslint-disable max-len */
             const document = new JSDOM("<html><body></body></html>").window.document;
 
-            expect(() => accessTokenInstance.fromDocument(document)).toThrowError();
+            expect(() => accessTokenInstance.fromDocument(document)).toThrow();
         });
 
         test("should throw error if data can't be parsed", () => {
-            /* eslint-disable max-len */
             const document = new JSDOM('<html><body><script id="data"></script></body></html>').window.document;
 
-            expect(() => accessTokenInstance.fromDocument(document)).toThrowError();
+            expect(() => accessTokenInstance.fromDocument(document)).toThrow();
         });
     });
 });

--- a/tst/reddit/RedditSession.test.ts
+++ b/tst/reddit/RedditSession.test.ts
@@ -65,10 +65,10 @@ describe("RedditSession", () => {
                     mockAccessToken.fromWindow.mockImplementation(() => {throw new Error();});
                     mockFetch.fetchDocument.mockReturnValue(Promise.reject(new Error()));
                     const promise1 = redditSession.updateAccessToken();
-                    await expect(promise1).rejects.toThrowError();
+                    await expect(promise1).rejects.toThrow();
                     const promise2 = redditSession.updateAccessToken();
                     expect(promise2).not.toBe(promise1);
-                    await expect(promise2).rejects.toThrowError();
+                    await expect(promise2).rejects.toThrow();
                 });
             });
         });
@@ -92,7 +92,7 @@ describe("RedditSession", () => {
                 mockAccessToken.fromWindow.mockReturnValue("access token");
                 mockFetch.fetchMutedSubreddits.mockReturnValue(Promise.reject(new Error()));
 
-                await expect(redditSession.updateMutedSubreddits()).rejects.toThrowError();
+                await expect(redditSession.updateMutedSubreddits()).rejects.toThrow();
             });
 
             describe("deduplication", () => {
@@ -111,10 +111,10 @@ describe("RedditSession", () => {
                 test("should return a new promise if the first rejects", async () => {
                     mockFetch.fetchMutedSubreddits.mockReturnValue(Promise.reject(new Error()));
                     const promise1 = redditSession.updateMutedSubreddits();
-                    await expect(promise1).rejects.toThrowError();
+                    await expect(promise1).rejects.toThrow();
                     const promise2 = redditSession.updateMutedSubreddits();
                     expect(promise2).not.toBe(promise1);
-                    await expect(promise2).rejects.toThrowError();
+                    await expect(promise2).rejects.toThrow();
                 });
             });
         });

--- a/tst/userscript/AsyncXMLHttpRequest.test.ts
+++ b/tst/userscript/AsyncXMLHttpRequest.test.ts
@@ -51,7 +51,7 @@ describe("AsyncXMLHttpRequest", () => {
         test("should reject onabort", async () => {
             const promise = new TestAsyncXMLHttpRequest().asyncXMLHttpRequest({url: "url"}, () => true);
             mockXMLHttpRequest.mock.calls[0][0].onabort?.();
-            await expect(promise).rejects.toThrowError();
+            await expect(promise).rejects.toThrow();
         });
 
         test("should reject onerror", async () => {
@@ -68,7 +68,7 @@ describe("AsyncXMLHttpRequest", () => {
         test("should reject ontimeout", async () => {
             const promise = new TestAsyncXMLHttpRequest().asyncXMLHttpRequest({url: "url"}, () => true);
             mockXMLHttpRequest.mock.calls[0][0].ontimeout?.();
-            await expect(promise).rejects.toThrowError();
+            await expect(promise).rejects.toThrow();
         });
 
         test("should reject onload when the predicate returns false", async () => {

--- a/tst/userscript/Storage.test.ts
+++ b/tst/userscript/Storage.test.ts
@@ -25,11 +25,11 @@ describe("Storage", () => {
 
     test("get", () => {
         storage.get(STORAGE_KEY.DEBUG);
-        expect(mockGetValue).toBeCalledWith(STORAGE_KEY.DEBUG, false);
+        expect(mockGetValue).toHaveBeenCalledWith(STORAGE_KEY.DEBUG, false);
     });
 
     test("set", () => {
         storage.set(STORAGE_KEY.DEBUG, true);
-        expect(mockSetValue).toBeCalledWith(STORAGE_KEY.DEBUG, true);
+        expect(mockSetValue).toHaveBeenCalledWith(STORAGE_KEY.DEBUG, true);
     });
 });

--- a/tst/utilities/AsyncMutationObserver.test.ts
+++ b/tst/utilities/AsyncMutationObserver.test.ts
@@ -69,7 +69,7 @@ describe("AsyncMutationObserver", () => {
             const asyncMutationObserver: AsyncMutationObserver = new TestAsyncMutationObserver(jest.fn());
             const promise = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            return expect(promise).resolves.not.toThrow();
+            await expect(promise).resolves.not.toThrow();
         });
 
         test("should resolve all promises on disconnect", async () => {
@@ -78,7 +78,7 @@ describe("AsyncMutationObserver", () => {
             const promise2 = asyncMutationObserver.observe(null as any);
             const promise3 = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            return expect(Promise.all([promise1, promise2, promise3])).resolves.not.toThrow();
+            await expect(Promise.all([promise1, promise2, promise3])).resolves.not.toThrow();
         });
 
         test("disconnect should reset, allowing for more observations", async () => {
@@ -100,7 +100,7 @@ describe("AsyncMutationObserver", () => {
             const promise = asyncMutationObserver.observe(null as any);
             const mutationObserverCallback = mutationObserverSupplier.mock.calls[0][0];
             mutationObserverCallback([], asyncMutationObserver);
-            return expect(promise).resolves.not.toThrow();
+            await expect(promise).resolves.not.toThrow();
         });
 
         test("should reject the promise on thrown error from the callback", async () => {

--- a/tst/utilities/AsyncMutationObserver.test.ts
+++ b/tst/utilities/AsyncMutationObserver.test.ts
@@ -32,9 +32,9 @@ describe("AsyncMutationObserver", () => {
 
             const mutationObserverCallback = mutationObserverSupplier.mock.calls[0][0];
 
-            expect(callback).toBeCalledTimes(0);
+            expect(callback).toHaveBeenCalledTimes(0);
             mutationObserverCallback([], asyncMutationObserver);
-            expect(callback).toBeCalledTimes(1);
+            expect(callback).toHaveBeenCalledTimes(1);
         });
 
         test("observer in callback should match the original observer", () => {
@@ -69,7 +69,7 @@ describe("AsyncMutationObserver", () => {
             const asyncMutationObserver: AsyncMutationObserver = new TestAsyncMutationObserver(jest.fn());
             const promise = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            await promise;
+            return expect(promise).resolves.not.toThrow();
         });
 
         test("should resolve all promises on disconnect", async () => {
@@ -78,17 +78,17 @@ describe("AsyncMutationObserver", () => {
             const promise2 = asyncMutationObserver.observe(null as any);
             const promise3 = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            await Promise.all([promise1, promise2, promise3]);
+            return expect(Promise.all([promise1, promise2, promise3])).resolves.not.toThrow();
         });
 
         test("disconnect should reset, allowing for more observations", async () => {
             const asyncMutationObserver: AsyncMutationObserver = new TestAsyncMutationObserver(jest.fn());
             const promise1 = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            await promise1;
+            await expect(promise1).resolves.not.toThrow();
             const promise2 = asyncMutationObserver.observe(null as any);
             asyncMutationObserver.disconnect();
-            await promise2;
+            await expect(promise2).resolves.not.toThrow();
         });
 
         test("should resolve the promise on disconnect from the callback", async () => {
@@ -100,7 +100,7 @@ describe("AsyncMutationObserver", () => {
             const promise = asyncMutationObserver.observe(null as any);
             const mutationObserverCallback = mutationObserverSupplier.mock.calls[0][0];
             mutationObserverCallback([], asyncMutationObserver);
-            await promise;
+            return expect(promise).resolves.not.toThrow();
         });
 
         test("should reject the promise on thrown error from the callback", async () => {
@@ -112,7 +112,7 @@ describe("AsyncMutationObserver", () => {
             const promise = asyncMutationObserver.observe(null as any);
             const mutationObserverCallback = mutationObserverSupplier.mock.calls[0][0];
             mutationObserverCallback([], asyncMutationObserver);
-            await expect(promise).rejects.toThrowError();
+            await expect(promise).rejects.toThrow();
         });
 
         test("should reject the promise on rejected promise from the callback", async () => {
@@ -124,7 +124,7 @@ describe("AsyncMutationObserver", () => {
             const promise = asyncMutationObserver.observe(null as any);
             const mutationObserverCallback = mutationObserverSupplier.mock.calls[0][0];
             mutationObserverCallback([], asyncMutationObserver);
-            await expect(promise).rejects.toThrowError();
+            await expect(promise).rejects.toThrow();
         });
     });
 });

--- a/tst/utilities/promisify.test.ts
+++ b/tst/utilities/promisify.test.ts
@@ -34,17 +34,17 @@ describe("promisify", () => {
 
     describe("resolved promise matches original function return", () => {
         test("emptyReturnVoid", async () => {
-            await expect(promisify(emptyReturnVoid)())
+            return expect(promisify(emptyReturnVoid)())
                 .resolves.toBeUndefined();
         });
 
         test("numberReturnVoid", async () => {
-            await expect(promisify(numberReturnVoid)(1))
+            return expect(promisify(numberReturnVoid)(1))
                 .resolves.toBeUndefined();
         });
 
         test("emptyReturnNumber", async () => {
-            await expect(promisify(emptyReturnNumber)())
+            return expect(promisify(emptyReturnNumber)())
                 .resolves.toBe(emptyReturnNumber());
         });
 
@@ -57,19 +57,23 @@ describe("promisify", () => {
                 }
             };
 
-            await expect(promisify(tReturnT)(obj))
+            return expect(promisify(tReturnT)(obj))
                 .resolves.toBe(tReturnT(obj));
         });
     });
 
     describe("rejected promise matches original function throw", () => {
         test("emptyThrowsError", async () => {
+            let expectedError: any;
             try {
                 emptyThrowsError();
             } catch (e) {
-                await expect(promisify(emptyThrowsError)())
-                    .rejects.toBe(e);
+                expectedError = e;
             }
+
+            expect(expectedError).toEqual(expect.anything());
+            return expect(promisify(emptyThrowsError)())
+                .rejects.toBe(expectedError);
         });
     });
 });

--- a/tst/utilities/promisify.test.ts
+++ b/tst/utilities/promisify.test.ts
@@ -34,17 +34,17 @@ describe("promisify", () => {
 
     describe("resolved promise matches original function return", () => {
         test("emptyReturnVoid", async () => {
-            return expect(promisify(emptyReturnVoid)())
+            await expect(promisify(emptyReturnVoid)())
                 .resolves.toBeUndefined();
         });
 
         test("numberReturnVoid", async () => {
-            return expect(promisify(numberReturnVoid)(1))
+            await expect(promisify(numberReturnVoid)(1))
                 .resolves.toBeUndefined();
         });
 
         test("emptyReturnNumber", async () => {
-            return expect(promisify(emptyReturnNumber)())
+            await expect(promisify(emptyReturnNumber)())
                 .resolves.toBe(emptyReturnNumber());
         });
 
@@ -57,7 +57,7 @@ describe("promisify", () => {
                 }
             };
 
-            return expect(promisify(tReturnT)(obj))
+            await expect(promisify(tReturnT)(obj))
                 .resolves.toBe(tReturnT(obj));
         });
     });
@@ -72,7 +72,7 @@ describe("promisify", () => {
             }
 
             expect(expectedError).toEqual(expect.anything());
-            return expect(promisify(emptyThrowsError)())
+            await expect(promisify(emptyThrowsError)())
                 .rejects.toBe(expectedError);
         });
     });

--- a/tst/web/Fetch.test.ts
+++ b/tst/web/Fetch.test.ts
@@ -165,7 +165,7 @@ describe("Fetch", () => {
             mockAsyncXMLHttpRequest.asyncXMLHttpRequest.mockReturnValue(Promise.resolve({
                 responseText: JSON.stringify({ data: {} })
             } as any));
-            await expect(fetch.fetchMutedSubreddits("access token, the accessor")).rejects.toThrowError();
+            await expect(fetch.fetchMutedSubreddits("access token, the accessor")).rejects.toThrow();
         });
     });
 });


### PR DESCRIPTION
## What are these changes?
Fix linter warnings/errors introduced from using the `jestPlugin.configs["flat/recommended"]` ruleset.

## Why are these changes being made?
Linter warnings and errors are bad.

## Checklist before merging
- [X] `./toolbox -- run clean-verify` succeeds.
